### PR TITLE
Added Information on How to Contribute

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,48 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in the CLI.NET Core community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience.
+- Focusing on what is best not just for us as individuals, but for the overall community.
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind.
+- Trolling, insulting or derogatory comments, and personal or political attacks.
+- Public or private harassment.
+- Publishing others' private information, such as a physical or email address, without their explicit permission.
+- Other conduct which could reasonably be considered inappropriate in a professional setting.
+
+## Enforcement Responsibilities
+
+The project maintainer is responsible for clarifying and enforcing the standards of acceptable behavior, and will take appropriate and fair corrective action in response to any behavior deemed inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces (issues, pull requests, discussions, commits), and also applies when an individual is officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainer, [David Neumann](https://github.com/lecode-official). All complaints will be reviewed and investigated promptly and fairly.
+
+The maintainer will follow these Community Impact Guidelines in determining the consequences for any violation:
+
+1. **Correction** — A private, written warning, providing clarity around the nature of the violation and why the behavior was inappropriate.
+2. **Warning** — A warning with consequences for continued behavior, including no interaction with the people involved for a specified period of time.
+3. **Temporary Ban** — A temporary ban from any sort of interaction or public communication with the project for a specified period of time.
+4. **Permanent Ban** — A permanent ban from any sort of public interaction within the project.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing to CLI.NET Core
+
+Thanks for your interest in contributing. This document covers the process. For the coding, documentation, and commit-message conventions themselves, see the [Developer Manual](docs/developer-manual/README.md).
+
+All participation is governed by the [Code of Conduct](CODE_OF_CONDUCT.md). Security vulnerabilities are handled separately — see [`SECURITY.md`](SECURITY.md) instead of filing a public issue.
+
+## Open an Issue First
+
+Before forking the repository and starting work, open an issue describing what you want to do. This aligns your idea with where the project is already headed and can save you from doing work that overlaps with something already planned.
+
+## Fork, Branch, and Pull Request
+
+Fork the repository and work on a feature branch. Pull requests are always welcome once the corresponding issue has been discussed. To help the pull request merge quickly:
+
+- Match the project's conventions: [C# Style](docs/developer-manual/conventions/csharp-style.md) or [Markdown Style](docs/developer-manual/conventions/markdown-style.md), depending on what you are changing, and [File Naming Conventions](docs/developer-manual/conventions/file-naming-conventions.md) for anything new.
+- Comment and document your code — see [C# Style](docs/developer-manual/conventions/csharp-style.md) for what a documentation comment and a plain comment are each expected to cover.
+- Run the linters and the code formatter before opening the pull request (see [Tooling](docs/developer-manual/tooling/README.md)). The same checks run in [Continuous Integration](docs/developer-manual/tooling/continuous-integration.md) on every push.
+- Write commit messages by [the project's rules](docs/developer-manual/conventions/commit-messages.md).
+
+## Update the Project's Records
+
+A pull request that adds a contribution is expected to also update the records that track the project's history:
+
+- **[`CONTRIBUTORS.md`](CONTRIBUTORS.md)** — Add yourself, in alphabetical order, if this is your first contribution. You may use our real name or a pseudonym, please link to your GitHub profile.
+- **[`CHANGELOG.md`](CHANGELOG.md)** — Document what changed under the version it will ship in.
+- **[`docs/`](docs/README.md)** — If your change affects how the project is built, used, or contributed to, update or add the relevant article.
+
+## Licensing of Contributions
+
+The project is licensed under LGPL-3.0 (see [`LICENSE`](LICENSE)). By contributing, you agree your contribution is licensed under the same terms, and, if your contribution includes anything you hold a patent on, that you grant the patent rights needed to use it. If your contribution contains anything a third party holds a patent for, you must provide written consent from the patent holder that grants the patent rights needed to use it. This is not legal advice — read the [license file](LICENSE) for the actual terms.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ The project uses a set of linters and a code formatter to (1) find and correct p
 
 ## Contributing
 
-If you'd like to contribute, there are multiple ways you can help out. If you find a bug or have a feature request, please feel free to open an issue on GitHub. If you want to contribute code, please fork the repository and use a feature branch. Pull requests are always welcome. Before forking, please open an issue where you describe what you want to do. This helps to align your ideas with mine and may prevent you from doing work, that I am already planning on doing. If you have contributed to the project, please add yourself to the [contributors list](CONTRIBUTORS.md) and document your changes in the [changelog](CHANGELOG.md). Also, if necessary, update the [documentation](docs/README.md). To help speed up the merging of your pull request, please comment and document your code extensively and try to emulate the coding style of the project.
+If you'd like to contribute, there are multiple ways you can help out — bug reports, feature requests, or code. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full process. Participation is governed by the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Security
+
+To report a security vulnerability, please do not open a public issue — see [`SECURITY.md`](SECURITY.md) for how to report it privately.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Supported Versions
+
+CLI.NET Core is a young, actively developed project with a single maintained line of development. Only the most recently published release receives security fixes. There is no long-term-support version to backport to.
+
+## Reporting a Vulnerability
+
+**Do not open a public issue for a security vulnerability.** Instead, use GitHub's private vulnerability reporting for this repository: go to the **Security** tab and choose **Report a vulnerability**. If that is not available to you, contact the maintainer, [David Neumann](https://github.com/lecode-official), directly instead of filing a public issue.
+
+Please include as much of the following as you can:
+
+- The affected version (see the NuGet package's `<Version>`, or the commit hash).
+- Steps to reproduce, or a minimal example that triggers the issue.
+- The impact you believe the vulnerability has.
+
+This is a project maintained by a single person in their spare time, so there is no formal Service Level Agreement (SLA) on response times, but reports are taken seriously and handled as promptly as possible. A fix, once available, is released and noted in [`CHANGELOG.md`](CHANGELOG.md). Credit is given to the reporter there unless anonymity is requested.
+
+## Related
+
+- How to contribute a fix once a vulnerability is disclosed: [`CONTRIBUTING.md`](CONTRIBUTING.md).
+- Community standards for all interactions, including security reports: [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).

--- a/tests/linters/.cspell.json
+++ b/tests/linters/.cspell.json
@@ -90,6 +90,7 @@
         "Neumann",
         "slnx",
         "Takumi",
+        "unreviewed",
         "vsicons",
         "wayou",
         "wordmark",


### PR DESCRIPTION
Added a contribution guide in `CONTRIBUTING.md`, which states how people may contribute to the project. The corresponding section in the project's was adapted to point to the contribution guide. Furthermore, a code of conduct was added in `CODE_OF_CONDUCT.md`, which was adapted from [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, and a security policy was added in `SECURITY.md`, which explains how to responsibly disclose security issues and how they are dealt with. All three documents were written using the help of Claude Code.

Closes issue #10.