### PR TITLE
Added Comprehensive Documentation for the Project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,16 +1,18 @@
 # CLAUDE.md
 
-Guidance for AI assistants working on CLI.NET Core.
+Guidance for AI assistants working on CLI.NET Core. Humans should read the [documentation](docs/README.md) too.
 
 ## What This Project Is
 
 CLI.NET Core is a .NET command line application framework, built in the style of ASP.NET Core: it lets consumers define commands and command-line arguments much the same way they would define actions and parameters for a Web API. The repository holds one solution, [`source/CLI.NET Core.slnx`](source/CLI.NET%20Core.slnx), with two projects — the framework itself (`clinet-core`) and a sample app that references it (`sample-app`). Both target `net10.0` with nullable reference types and implicit usings enabled.
 
+Start from [docs/developer-manual/architecture/overview.md](docs/developer-manual/architecture/overview.md).
+
 ## Golden Rules
 
-- **Match the surrounding code** This code is heavily and consistently documented — follow it.
-- **Formatting is owned by dprint** Markdown, JSON, XML (including `.csproj`/`.slnx`), YAML, and TOML — never add a lint rule that reformats one of these. Run `dprint fmt` before finishing. **C# is not covered by dprint** (there is no C# plugin configured); its whitespace comes from [`.editorconfig`](.editorconfig), so review it by eye.
-- **Run the linters before finishing** — there is no npm-script wrapper, so invoke them directly:
+- **Match the surrounding code and the documented conventions** ([docs/developer-manual/conventions/](docs/developer-manual/conventions/csharp-style.md)). This code is heavily and consistently documented — follow it.
+- **Formatting is owned by dprint** ([docs/developer-manual/tooling/formatting-dprint.md](docs/developer-manual/tooling/formatting-dprint.md)) for Markdown, JSON, XML (including `.csproj`/`.slnx`), YAML, and TOML — never add a lint rule that reformats one of these. Run `dprint fmt` before finishing. **C# is not covered by dprint** (there is no C# plugin configured); its whitespace comes from [`.editorconfig`](.editorconfig) and its style from [C# Style](docs/developer-manual/conventions/csharp-style.md) alone, so review it by eye.
+- **Run the linters before finishing** — there is no npm-script wrapper, so invoke them directly with the versions [Continuous Integration](docs/developer-manual/tooling/continuous-integration.md) pins:
 
   ```shell
   dprint check "**/*"
@@ -18,14 +20,14 @@ CLI.NET Core is a .NET command line application framework, built in the style of
   npx --yes markdownlint-cli2@0.23.0 --config tests/linters/.markdownlint.yml "**/*.md" "#**/bin/**" "#**/obj/**"
   ```
 
-  This file is Markdown and is linted too.
-- **Markdown headings are title case** at every level, in every file. Preserve the real casing of code spans, brand names (`dprint`), and acronyms.
-- **Prose uses periods, not semicolons.** In prose (docs, XML documentation comments, commit messages, this file) end each sentence with a period rather than joining two with a semicolon. Plain in-code comments (`//`) do the reverse: sentences are separated by semicolons and the last one takes no terminal punctuation.
-- **C# structure**: file-scoped namespaces, an XML documentation comment (`<summary>`, `<param>`, `<returns>`) on every public and internal member, `<inheritdoc/>` for members that implement an interface or override a base member, `sealed` classes by default (composition over inheritance for anything that would otherwise need to extend a sealed framework type), explicit `this.` on member access, expression-bodied members where the implementation is a single expression, and `camelCase` private fields with no underscore.
+  The docs and this file are Markdown and are linted too.
+- **Markdown headings are title case** at every level, in every file ([docs/developer-manual/conventions/markdown-style.md](docs/developer-manual/conventions/markdown-style.md)). Preserve the real casing of code spans, brand names (`dprint`), and acronyms.
+- **Prose uses periods, not semicolons.** In prose (docs, XML documentation comments, commit messages, this file) end each sentence with a period rather than joining two with a semicolon. Plain in-code comments (`//`) do the reverse: sentences are separated by semicolons and the last one takes no terminal punctuation ([docs/developer-manual/conventions/csharp-style.md](docs/developer-manual/conventions/csharp-style.md)).
+- **C# structure**: file-scoped namespaces, an XML documentation comment (`<summary>`, `<param>`, `<returns>`) on every public and internal member, `<inheritdoc/>` for members that implement an interface or override a base member, `sealed` classes by default (composition over inheritance for anything that would otherwise need to extend a sealed framework type), explicit `this.` on member access, expression-bodied members where the implementation is a single expression, and `camelCase` private fields with no underscore. Full detail: [C# Style](docs/developer-manual/conventions/csharp-style.md).
 - **Nullable reference types and implicit usings are enabled everywhere.** Write genuinely null-safe code rather than silencing the analyzer.
-- **Files and directories are kebab-case**, except well-known and tool-mandated names (`README.md`, `LICENSE`, `.editorconfig`, ...). Inside a C# project's own source tree, directories and files switch to PascalCase, one type per file.
-- **Every dependency is pinned to an exact version — never a range.** NuGet packages, dprint plugins, and the linter versions CI installs are all pinned exactly. Every C# project sets `RestorePackagesWithLockFile`, so a `PackageReference` version bump must be followed by `dotnet restore` and the resulting `packages.lock.json` change committed alongside it.
-- **Write commit messages by the rules** — the 50/72 rule, a title-cased, past-tense subject, and a prose body. State whether AI was involved and, if it was, what exactly the AI did — this project is developed openly with AI assistance and the commit history is where that is tracked (see the "Use of AI" section of the [root README](README.md)). When you did any of the work, add the trailer this project uses (not a model-specific one):
+- **Files and directories are kebab-case**, except well-known and tool-mandated names (`README.md`, `LICENSE`, `.editorconfig`, ...). Inside a C# project's own source tree, directories and files switch to PascalCase, one type per file. Full detail: [File Naming Conventions](docs/developer-manual/conventions/file-naming-conventions.md).
+- **Every dependency is pinned to an exact version — never a range.** NuGet packages, dprint plugins, and the linter versions CI installs are all pinned exactly. Every C# project sets `RestorePackagesWithLockFile`, so a `PackageReference` version bump must be followed by `dotnet restore` and the resulting `packages.lock.json` change committed alongside it. Full detail: [Dependency Management](docs/developer-manual/conventions/dependency-management.md).
+- **Write commit messages by the rules** ([docs/developer-manual/conventions/commit-messages.md](docs/developer-manual/conventions/commit-messages.md)) — the 50/72 rule, a title-cased, past-tense subject, and a prose body. State whether AI was involved and, if it was, what exactly the AI did — this project is developed openly with AI assistance and the commit history is where that is tracked (see the "Use of AI" section of the [root README](README.md)). When you did any of the work, add the trailer this project uses (not a model-specific one):
 
   ```text
   Co-Authored-By: Claude <noreply@anthropic.com>
@@ -33,6 +35,29 @@ CLI.NET Core is a .NET command line application framework, built in the style of
 
 - **Delegating to subagents is pre-approved.** `.claude/settings.json` allows the agent/subagent tool by default, so use one whenever a task genuinely benefits from parallel or isolated work, without asking first.
 
+## When Working on X, Read Y
+
+- **Repository layout, the solution, the projects** → [docs/developer-manual/architecture/](docs/developer-manual/architecture/overview.md).
+- **C# source code** → [docs/developer-manual/conventions/csharp-style.md](docs/developer-manual/conventions/csharp-style.md).
+- **Linting, formatting, spell checking, CI, editor setup** → [docs/developer-manual/tooling/](docs/developer-manual/tooling/README.md).
+- **Markdown and documentation style** → [docs/developer-manual/conventions/markdown-style.md](docs/developer-manual/conventions/markdown-style.md).
+- **Writing commit messages** → [docs/developer-manual/conventions/commit-messages.md](docs/developer-manual/conventions/commit-messages.md).
+- **Naming a new file or directory** → [docs/developer-manual/conventions/file-naming-conventions.md](docs/developer-manual/conventions/file-naming-conventions.md).
+- **Adding or upgrading a dependency** → [docs/developer-manual/conventions/dependency-management.md](docs/developer-manual/conventions/dependency-management.md).
+- **Opening an issue, submitting a pull request, the AI-contribution policy, updating `CONTRIBUTORS.md`/`CHANGELOG.md`** → [CONTRIBUTING.md](CONTRIBUTING.md).
+- **How consumers use the framework** → [docs/user-manual/](docs/user-manual/README.md).
+
 ## Conventions in Brief
 
-Files use file-scoped namespaces and, in larger files, `#region` blocks (`Constructors`, `Private Fields`, `Public Methods`, and so on) to group members — small files skip regions entirely. Every public and internal member is documented with XML comments that explain *why*, not just what. Sealed types compose the framework types they wrap instead of inheriting from them. Markdown headings are title case everywhere, and prose ends sentences with periods; plain code comments do the reverse.
+Files use file-scoped namespaces and, in larger files, `#region` blocks (`Constructors`, `Private Fields`, `Public Methods`, and so on) to group members — small files skip regions entirely. Every public and internal member is documented with XML comments that explain *why*, not just what. Sealed types compose the framework types they wrap instead of inheriting from them. Markdown headings are title case everywhere, and prose ends sentences with periods; plain code comments do the reverse. Full detail: [docs/developer-manual/conventions/](docs/developer-manual/conventions/csharp-style.md).
+
+## Keep the Documentation up to Date
+
+**This is important.** Whenever you change, add, remove, or discover something about the project, update the relevant [`docs/`](docs/README.md) article **and** this `CLAUDE.md` in the same change:
+
+- Keep the "When working on X" routing table above accurate.
+- Keep the [docs index](docs/README.md) and the [Developer Manual index](docs/developer-manual/README.md) accurate — every article must be listed.
+- If a change introduces a topic that does not fit an existing article, add a new small, single-topic article, link it from the relevant index, and reference it here if relevant.
+- If a change invalidates something a doc says, fix the doc — do not leave it stale.
+
+Treat the docs as part of the code: a change is not done until the docs and this file reflect it.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,8 @@
 # Documentation
 
-Welcome to the documentation of CLI.NET Core, a .NET command line application framework in the style of ASP.NET Core. It allows you to define commands and command line arguments in much the same way you would define actions and arguments for a Web API in ASP.NET Core.
+![CLI.NET Core Logo](../design/readme-header-dark.png#gh-dark-mode-only) ![CLI.NET Core Logo](../design/readme-header-light.png#gh-light-mode-only)
+
+Welcome to the documentation of CLI.NET Core, a .NET command line application framework in the style of ASP.NET Core. It allows you to define commands and command line arguments in much the same way you would define actions and arguments for a Web API in ASP.NET Core. This documentation is split into two parts:
+
+1. [Developer Manual](developer-manual/README.md) — for people working on the CLI.NET Core codebase itself.
+2. [User Manual](user-manual/README.md) — for people building a command line application with CLI.NET Core.

--- a/docs/developer-manual/README.md
+++ b/docs/developer-manual/README.md
@@ -1,0 +1,19 @@
+# Developer Manual
+
+This manual is for people working on the CLI.NET Core codebase itself: where things live, how the code is styled, and how the project is built, linted, and formatted.
+
+1. [Architecture](architecture/README.md)
+   1. [Overview](architecture/overview.md)
+2. [Tooling](tooling/README.md)
+   1. [Visual Studio Code Integration](tooling/vscode-integration.md)
+   2. [Spell Checking (CSpell)](tooling/spell-checking-cspell.md)
+   3. [MarkdownLint](tooling/linting-markdownlint.md)
+   4. [dprint](tooling/formatting-dprint.md)
+   5. [Continuous Integration](tooling/continuous-integration.md)
+3. [Conventions](conventions/README.md)
+   1. [C# Style](conventions/csharp-style.md)
+   2. [Markdown Style](conventions/markdown-style.md)
+   3. [Commit Messages](conventions/commit-messages.md)
+   4. [File Naming Conventions](conventions/file-naming-conventions.md)
+   5. [Dependency Management](conventions/dependency-management.md)
+4. [Contributing](contributing.md)

--- a/docs/developer-manual/architecture/README.md
+++ b/docs/developer-manual/architecture/README.md
@@ -1,0 +1,5 @@
+# Architecture
+
+This section covers how the repository and the code inside it are put together:
+
+1. [Overview](overview.md)

--- a/docs/developer-manual/architecture/overview.md
+++ b/docs/developer-manual/architecture/overview.md
@@ -1,0 +1,37 @@
+# Overview
+
+This article covers how the repository is laid out and how the .NET projects inside it are configured.
+
+## Repository Layout
+
+The repository is organized into a few top-level directories:
+
+- [`source/`](../../../source/) — The source code of the CLI.NET Core framework itself, and the sample app that demonstrates it.
+- [`tests/`](../../../tests/) — Unit and integration tests, plus the configuration for the linters and the code formatter (see [Tooling](../tooling/README.md)).
+- [`docs/`](../../README.md) — This documentation.
+- [`design/`](../../../design/) — Logo and brand assets, and the [design guide](../../../design/DESIGN.md) that governs them.
+
+Top-level files round out the repository: [`README.md`](../../../README.md) is the project's front door, [`CHANGELOG.md`](../../../CHANGELOG.md) records what changed in each version, [`CONTRIBUTORS.md`](../../../CONTRIBUTORS.md) lists everyone who has contributed, and [`LICENSE`](../../../LICENSE) is the full text of the license (see [Contributing](../contributing.md) for how these are kept up to date). [`CONTRIBUTING.md`](../../../CONTRIBUTING.md), [`CODE_OF_CONDUCT.md`](../../../CODE_OF_CONDUCT.md), and [`SECURITY.md`](../../../SECURITY.md) round out the community-facing files GitHub recognizes by name.
+
+## Solution and Projects
+
+[`source/CLI.NET Core.slnx`](../../../source/CLI.NET%20Core.slnx) is the solution file, in the newer XML-based `.slnx` format rather than the classic `.sln` format. It groups two projects:
+
+- **`clinet-core`** ([`CLI.NET Core.csproj`](../../../source/clinet-core/CLI.NET%20Core.csproj)) — The framework itself, packed and published as the `CliNetCore` NuGet package.
+- **`sample-app`** ([`CLI.NET Core Sample App.csproj`](../../../source/sample-app/CLI.NET%20Core%20Sample%20App.csproj)) — A runnable sample application that references `clinet-core` via a project reference and demonstrates how the framework is used.
+
+Both projects target `net10.0`, and both enable `<Nullable>` and `<ImplicitUsings>`. `clinet-core` additionally sets `<GenerateDocumentationFile>`, so that the XML documentation comments in the source (see [C# Style](../conventions/csharp-style.md)) ship alongside the compiled assembly and are available to consumers of the NuGet package through their editor's tooltips.
+
+`clinet-core` depends on the `Microsoft.Extensions.Hosting` NuGet package — the same generic-host infrastructure ASP.NET Core itself builds on. This dependency is what lets CLI.NET Core mirror the ASP.NET Core hosting model for command-line applications, as described in the [root README](../../../README.md).
+
+## Versioning and Licensing
+
+The NuGet package version is set independently in each `.csproj`'s `<Version>` property. [`CHANGELOG.md`](../../../CHANGELOG.md) is the human-readable history of what each version changed; it is not generated from Git history, so it needs to be updated by hand (see [Contributing](../contributing.md)).
+
+The project is licensed under LGPL-3.0 (see [`LICENSE`](../../../LICENSE)). Every `.csproj` mirrors this in its NuGet metadata.
+
+## Related
+
+- Coding conventions for the C# source: [C# Style](../conventions/csharp-style.md).
+- Linters, the code formatter, and editor setup: [Tooling](../tooling/README.md).
+- How to propose and submit changes: [Contributing](../contributing.md).

--- a/docs/developer-manual/contributing.md
+++ b/docs/developer-manual/contributing.md
@@ -1,0 +1,11 @@
+# Contributing
+
+The process for proposing and submitting changes — opening an issue first, forking and branching, the pull request checklist, the AI-assistance policy, updating `CONTRIBUTORS.md`/`CHANGELOG.md`, and the licensing terms a contribution is made under — is covered by the root [`CONTRIBUTING.md`](../../CONTRIBUTING.md), not duplicated here.
+
+Participation is governed by [`CODE_OF_CONDUCT.md`](../../CODE_OF_CONDUCT.md), and security vulnerabilities are reported through [`SECURITY.md`](../../SECURITY.md) rather than as a public issue.
+
+## Related
+
+- Where the code you are changing likely lives: [Architecture](architecture/overview.md).
+- The tools that check your change before it merges: [Tooling](tooling/README.md).
+- The conventions a change is expected to follow: [Conventions](conventions/README.md).

--- a/docs/developer-manual/conventions/README.md
+++ b/docs/developer-manual/conventions/README.md
@@ -1,0 +1,9 @@
+# Conventions
+
+This article summarizes the coding and styling conventions for the project:
+
+1. [C# Style](csharp-style.md)
+2. [Markdown Style](markdown-style.md)
+3. [Commit Messages](commit-messages.md)
+4. [File Naming Conventions](file-naming-conventions.md)
+5. [Dependency Management](dependency-management.md)

--- a/docs/developer-manual/conventions/commit-messages.md
+++ b/docs/developer-manual/conventions/commit-messages.md
@@ -1,0 +1,50 @@
+# Commit Messages
+
+This article covers how commit messages are written in this repository. It applies to everyone, human and AI assistant alike.
+
+## The 50/72 Rule
+
+Commit messages follow the conventional 50/72 rule:
+
+- The subject line is at most 50 characters.
+- A single blank line separates the subject from the body.
+- Every body line is wrapped at most 72 characters — unlike the documentation, which is never manually wrapped (see [Markdown Style](markdown-style.md)).
+
+The subject is a complete summary on its own. The body is optional — a small, self-explanatory change may be subject-only.
+
+## Subject Line
+
+The subject is **title case** (see [Markdown Style](markdown-style.md)) and **past tense**, describing what the commit did: `Added a GitHub Actions Workflow`, `Created a New Logo`, `Scaffolded the New Project`. As in a Markdown heading, the natural casing of code identifiers and brand names is preserved. It does not end with a period.
+
+## Body
+
+When present, the body explains what changed and why — the diff already shows what changed, so the *why* is what earns its place. It is written as prose paragraphs, bulleted or numbered lists, or a mix of both, freely intermixed (an opening paragraph followed by a list, followed by another paragraph, is fine). Whichever form it takes, it follows the same punctuation rule as the rest of the documentation: periods, not semicolons (see [Markdown Style](markdown-style.md)).
+
+## Disclosing AI Involvement
+
+Every commit message states whether AI was involved in producing it and, if it was, what exactly the AI did — this project is developed openly with AI assistance, and the commit history is where that involvement is tracked (see the "Use of AI" section of the [root README](../../../README.md)). A commit written entirely by hand carries no such note. A commit where AI was involved:
+
+- Says in the body what the AI actually did (wrote the documentation, generated a design asset, tracked down a bug, and so on).
+- Carries a trailer at the end of the body:
+
+  ```text
+  Co-Authored-By: Claude <noreply@anthropic.com>
+  ```
+
+## Example
+
+```text
+Added a GitHub Actions Workflow
+
+A new GitHub Actions Workflow was added, which runs the linters and
+the code formatter on every push to any branch.
+
+The workflow was created using Claude Code.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+## Related
+
+- The punctuation and title-case rules these messages follow: [Markdown Style](markdown-style.md).
+- The full policy on AI-assisted work: the "Use of AI" section of the [root README](../../../README.md), and [Contributing](../contributing.md).

--- a/docs/developer-manual/conventions/csharp-style.md
+++ b/docs/developer-manual/conventions/csharp-style.md
@@ -1,0 +1,50 @@
+# C# Style
+
+This article covers the conventions for C# code in [`source/`](../../../source/). It is about style and structure on top of the language itself — for the repository layout the code lives in, see [Architecture](../architecture/overview.md).
+
+## File Layout
+
+Every file starts with a file-scoped namespace declaration (`namespace CliNetCore.Hosting;`), not a namespace block. Beyond the usings that [`ImplicitUsings`](../architecture/overview.md) already brings in, additional `using` directives are wrapped in a `#region Using Directives` block above the namespace declaration.
+
+Within a type, members may be grouped into `#region` blocks when the file is large enough to benefit from it, for example `#region Constructors`, `#region Private Fields`, `#region Public Static Methods`, `#region Public Methods`, or `#region <InterfaceName> Implementation` for the members that implement a specific interface. A small file with only a handful of members does not need regions at all — do not add them just for the sake of having them.
+
+## Documentation Comments
+
+Every public and internal member has an XML documentation comment (`GenerateDocumentationFile` is enabled in [the project files](../architecture/overview.md), so these ship in the compiled output). A `<summary>` explains not just what a member does, but why it exists and how it relates to the rest of the design — the reasoning belongs next to the code, not only in a commit message. Parameters and return values are documented with `<param>` and `<returns>`. When a member implements an interface member or overrides a base member and has nothing to add beyond what is already documented there, use `<inheritdoc/>` instead of repeating the text.
+
+Prose inside documentation comments follows the same punctuation rule as the rest of the documentation: periods, not semicolons (see [Markdown Style](markdown-style.md)).
+
+## Plain Comments
+
+A plain `//` comment inside a method body is not prose — it explains a non-obvious *why* (a hidden constraint, an ordering requirement, a workaround) that the code next to it does not already make clear. It follows the opposite punctuation rule from documentation comments and the rest of the documentation: sentences are separated by semicolons, and the last one takes no terminal punctuation.
+
+```csharp
+// The fallback is only registered if the consumer did not register one of their own, so that the type stays usable out of the box while still
+// letting a caller replace the behavior entirely simply by registering their own implementation
+```
+
+Do not write a comment that only restates what the code already says. If removing it would not confuse a future reader, it should not be there.
+
+## Types and Members
+
+- **Classes are `sealed` by default.** A type is only left unsealed when it is deliberately designed as a base class for extension. Where a type needs to reuse behavior from a sealed framework type it cannot inherit from (for example, a concrete host or builder from `Microsoft.Extensions.Hosting`), it wraps that type and forwards to it (composition) instead.
+- **Prefer expression-bodied members** (`=>`) for members whose implementation is a single expression, including constructors, property getters, and simple methods.
+- **Access instance members through `this.`** explicitly, even in a constructor or method where the name would resolve unambiguously without it.
+- **Async methods are suffixed `Async`** and return `Task` or `Task<T>`. They accept a `CancellationToken` (typically the last parameter) whenever the work they do can meaningfully be canceled.
+- **Prefer factory methods over public constructors** when a type has invariants to establish or work to do beyond simple field assignment. An `internal` constructor paired with a `public static` creation method (or a dedicated builder type) keeps construction explicit and controllable.
+- **Interfaces are prefixed with `I`** (`IDisposable`), following the standard .NET convention.
+- **Private fields are `camelCase`** with no leading underscore and no `_` prefix.
+
+## Nullability and Implicit Usings
+
+Every project enables `<Nullable>enable</Nullable>` and `<ImplicitUsings>enable</ImplicitUsings>` (see [Architecture](../architecture/overview.md)). Write code that is genuinely null-safe rather than silencing the analyzer with `!`; a nullable parameter or return type should mean that `null` is a real, handled case.
+
+## Formatting
+
+C# is **not** formatted by [dprint](../tooling/formatting-dprint.md) — dprint has no C# plugin in this project, so `.csproj` and `.slnx` files are formatted by it (they are XML), but `.cs` files are not. Indentation and basic whitespace rules for C# come from [`.editorconfig`](../../../.editorconfig) (4 spaces, no tabs), which most editors, including Visual Studio Code, apply automatically. Beyond what `.editorconfig` enforces, matching the conventions on this page during review is the only guard C# has today.
+
+## Related
+
+- Where these files live in the repository: [Architecture](../architecture/overview.md).
+- The punctuation rule for prose versus plain comments also governs [Markdown Style](markdown-style.md).
+- Formatting for the file types dprint does own: [dprint](../tooling/formatting-dprint.md).

--- a/docs/developer-manual/conventions/dependency-management.md
+++ b/docs/developer-manual/conventions/dependency-management.md
@@ -1,0 +1,30 @@
+# Dependency Management
+
+This article covers how dependencies — NuGet packages, but also the linters and code formatter from [Tooling](../tooling/README.md) — are pinned and locked in this repository.
+
+## Exact Versions, Never Ranges
+
+Every dependency is pinned to an exact version — never a floating range (`*`), a minimum-version range, or a wildcard. A `PackageReference` in a `.csproj` looks like this:
+
+```xml
+<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+```
+
+not `Version="10.*"` or `Version="[10.0.0,)"`. The same rule applies outside of NuGet: the dprint plugins in [`dprint.json`](../../../dprint.json) are pinned to an exact release URL, and [Continuous Integration](../tooling/continuous-integration.md) installs `dprint`, `cspell`, and `markdownlint-cli2` at exact, explicit versions. An upgrade is always a deliberate, visible change to a version string, never something that happens silently on the next restore.
+
+## Lock Files
+
+Every C# project sets:
+
+```xml
+<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+```
+
+which makes `dotnet restore` generate and verify a `packages.lock.json` file next to the project, recording the exact resolved version and content hash of every direct and transitive NuGet dependency. This file is committed to source control. With it in place, a restore fails loudly if the resolved dependency graph would differ from what is locked — for example because a transitive dependency's version range allows a newer release — instead of silently picking up a different set of packages than the last person who restored the project.
+
+When a `PackageReference` version changes, run `dotnet restore` again to regenerate the affected `packages.lock.json` and commit it alongside the `.csproj` change; the two must move together.
+
+## Related
+
+- Where the `.csproj` files that set this live: [Architecture](../architecture/overview.md).
+- The pinned tool versions used outside of NuGet: [Continuous Integration](../tooling/continuous-integration.md).

--- a/docs/developer-manual/conventions/file-naming-conventions.md
+++ b/docs/developer-manual/conventions/file-naming-conventions.md
@@ -1,0 +1,25 @@
+# File Naming Conventions
+
+This article covers how files and directories are named throughout the repository.
+
+## Kebab-Case by Default
+
+Files and directories are named in **kebab-case** — lowercase words separated by hyphens — for example `command-line-parser`, `sample-app`, `developer-manual`, `formatting-dprint.md`. This applies repository-wide: source directories at the top level, the `docs/` tree, and any Markdown article.
+
+## Well-Known Exceptions
+
+Files with a conventional, tool- or ecosystem-mandated name keep that name instead of being renamed to kebab-case. This covers two kinds of files:
+
+- **Files everyone recognizes by their standard name**: `README.md`, `CLAUDE.md`, `LICENSE`, `CHANGELOG.md`, `CONTRIBUTORS.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`.
+- **Files whose name is dictated by the tool that reads them**: `.editorconfig`, `.gitignore`, `.gitattributes`, `dprint.json`, `.cspell.json`, `.markdownlint.yml`, and so on. Renaming these would simply stop the tool from finding them.
+
+## PascalCase Inside C# Projects
+
+Inside a C# project's own source tree, directories and files switch to **PascalCase** — for example `source/clinet-core/Hosting/CliApplication.cs`. This follows the standard .NET convention of naming a file after the single type it contains, and grouping related types into a PascalCase namespace folder. The project's own top-level folder (`clinet-core`, `sample-app`) still follows the repository's kebab-case rule — the switch to PascalCase only happens once you are inside the project, looking at its namespaces and types.
+
+The project and solution files themselves (`CLI.NET Core.csproj`, `CLI.NET Core Sample App.csproj`, `CLI.NET Core.slnx`) are named after the product, spaces included, rather than either convention — see [Architecture](../architecture/overview.md) for where they live.
+
+## Related
+
+- Where these directories and projects sit in the repository: [Architecture](../architecture/overview.md).
+- The naming rules that apply once you are inside a C# file: [C# Style](csharp-style.md).

--- a/docs/developer-manual/conventions/markdown-style.md
+++ b/docs/developer-manual/conventions/markdown-style.md
@@ -1,0 +1,37 @@
+# Markdown Style
+
+This article covers the conventions for Markdown files (this documentation, `README.md`, etc.). Markdown linting itself is handled by MarkdownLint (see [MarkdownLint](../tooling/linting-markdownlint.md)). This is about the conventions on top.
+
+## Headings Are Title Case
+
+Every heading — at every level, in every Markdown file — uses **title case**, not sentence case. Write `## Running the App`, not `## Running the app`.
+
+The rules:
+
+- Capitalize the first and last word, and every major word in between (nouns, verbs, adjectives, adverbs, pronouns, and subordinating conjunctions).
+- Keep minor words lowercase unless they are first or last: articles (`a`, `an`, `the`), coordinating conjunctions (`and`, `but`, `or`, `nor`, `for`, `so`, `yet`), and short prepositions (`as`, `at`, `by`, `for`, `from`, `in`, `into`, `of`, `off`, `on`, `per`, `to`, `up`, `via`, `vs`, `with`).
+- In a hyphenated compound, apply the same rules to each part: `Main-CLI Build`, `One-off-Lifecycle Events`.
+
+## Preserve Exact Casing of Names and Code
+
+Title case never overrides the real casing of a name. Leave these exactly as they are written:
+
+- Code spans stay verbatim, including surrounding backticks: ``## The `bootstrap` Pattern``.
+- Brand and tool names keep their own casing, including intentionally lowercase ones: `dprint`.
+- Acronyms and proper technology names stay as-is: `CLI`, `macOS`, `i18n`.
+
+When a name is intrinsically lowercase, it stays lowercase even as the first word: `## dprint Owns Formatting`.
+
+## Punctuation
+
+- **Prefer a period over a semicolon.** Where a semicolon joins two full sentences, split them into two sentences with a period instead. This applies to all prose — the documentation, `README.md`, etc. In-code comments are the one exception and follow their own rule (see [C# Style](csharp-style.md)).
+- **Use em and en dashes sparingly.** They fit a genuine aside or an abrupt break, not as a default connector. When a comma, a period, or parentheses reads just as well, use that instead.
+
+## No Horizontal Rules
+
+Never use horizontal rules (`---`) to separate sections. Headings already provide the structure. A `---` at the top of a file is only ever front matter, never a divider.
+
+## Related
+
+- Markdown linting: [MarkdownLint](../tooling/linting-markdownlint.md).
+- The other conventions: [C# Style](csharp-style.md).

--- a/docs/developer-manual/tooling/README.md
+++ b/docs/developer-manual/tooling/README.md
@@ -1,0 +1,11 @@
+# Tooling
+
+This section gives an overview of the tools used for development, including code editors and IDEs, linters, and code formatters:
+
+1. [Visual Studio Code Integration](vscode-integration.md)
+2. [Spell Checking (CSpell)](spell-checking-cspell.md)
+3. [MarkdownLint](linting-markdownlint.md)
+4. [dprint](formatting-dprint.md)
+5. [Continuous Integration](continuous-integration.md)
+
+None of these tools are installed as project dependencies (there is no Node.js package manifest in this repository) — they are run directly from the command line, either installed globally or invoked on demand through `npx`. [Continuous Integration](continuous-integration.md) installs pinned versions of all three explicitly; running them locally with the same versions keeps results consistent with what CI reports.

--- a/docs/developer-manual/tooling/continuous-integration.md
+++ b/docs/developer-manual/tooling/continuous-integration.md
@@ -1,0 +1,23 @@
+# Continuous Integration
+
+This article covers the GitHub Actions workflow in [`.github/workflows/linters.yml`](../../../.github/workflows/linters.yml).
+
+## What It Runs
+
+The workflow runs on every push, to any branch. A single job, on the latest Ubuntu runner, checks out the repository, installs Node.js 24, installs pinned versions of the three tools this project relies on for formatting and linting, and then runs each of them in turn:
+
+- `dprint check "**/*"` — verifies that every file dprint covers is already formatted (see [dprint](formatting-dprint.md)); unlike `dprint fmt`, it never modifies a file.
+- `cspell lint --config tests/linters/.cspell.json --no-progress "**/*"` — spell-checks the whole repository (see [Spell Checking (CSpell)](spell-checking-cspell.md)).
+- `markdownlint-cli2 --config tests/linters/.markdownlint.yml "**/*.md" "#**/bin/**" "#**/obj/**"` — lints every Markdown file, excluding build output (see [MarkdownLint](linting-markdownlint.md)).
+
+The spell-checking and Markdown-linting steps run even if an earlier step failed (`if: ${{ !cancelled() }}`), so a single failing tool does not hide findings from the others — the workflow always reports everything it can in one run.
+
+## Keeping Versions in Sync
+
+The tool versions installed in the workflow (`dprint`, `cspell`, `markdownlint-cli2`) are pinned exactly. When running these tools locally (see the "Running It" section of each tool's article), use the same pinned versions so that a local pass reliably predicts a green CI run.
+
+There is currently no separate build or test job — the framework's own test suite (see [`tests/unit-tests`](../../../tests/unit-tests/)) is not yet wired into this workflow.
+
+## Related
+
+- [dprint](formatting-dprint.md), [Spell Checking (CSpell)](spell-checking-cspell.md), and [MarkdownLint](linting-markdownlint.md) — the three tools this workflow runs.

--- a/docs/developer-manual/tooling/formatting-dprint.md
+++ b/docs/developer-manual/tooling/formatting-dprint.md
@@ -1,0 +1,28 @@
+# Formatting (dprint)
+
+This article covers code formatting, which is owned entirely by [dprint](https://dprint.dev).
+
+Configuration lives in [`dprint.json`](../../../dprint.json). dprint formats Markdown, JSON, XML (including `.csproj` and `.slnx` files, which are explicitly associated with the XML plugin), YAML, and TOML — **not C#**, since no C# formatting plugin is configured. C# indentation instead comes from [`.editorconfig`](../../../.editorconfig) and is otherwise a matter of following [C# Style](../conventions/csharp-style.md) during review.
+
+## Running It
+
+```shell
+dprint fmt
+```
+
+formats every file dprint is configured to handle, in place. To check formatting without modifying anything (what [Continuous Integration](continuous-integration.md) does):
+
+```shell
+dprint check "**/*"
+```
+
+Visual Studio Code is also configured to run dprint on save (see [Visual Studio Code Integration](vscode-integration.md)).
+
+## dprint Owns Formatting — Linters Must Not
+
+Because dprint is the single source of truth for formatting the file types it covers, the linters are configured to disable any rule that would reformat code. When adding a lint rule, never enable one that conflicts with dprint.
+
+## Related
+
+- Why C# is excluded and what governs its style instead: [C# Style](../conventions/csharp-style.md).
+- The check-mode invocation CI uses: [Continuous Integration](continuous-integration.md).

--- a/docs/developer-manual/tooling/linting-markdownlint.md
+++ b/docs/developer-manual/tooling/linting-markdownlint.md
@@ -1,0 +1,26 @@
+# MarkdownLint
+
+This article covers Markdown linting.
+
+Markdown (including these docs) is linted by [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2), configured in [`.markdownlint.yml`](../../../tests/linters/.markdownlint.yml).
+
+## Configuration
+
+The config keeps the default rules but disables line-length (prose is not hard-wrapped) and allows the `kbd` inline-HTML element. Because line-length is off, do not manually wrap prose lines.
+
+## Running It
+
+```shell
+npx --yes markdownlint-cli2@0.23.0 --config tests/linters/.markdownlint.yml "**/*.md" "#**/bin/**" "#**/obj/**"
+```
+
+The version matches the one [Continuous Integration](continuous-integration.md) installs. The trailing `#`-prefixed globs are `markdownlint-cli2`'s negated-glob syntax (it has no `--ignore` flag) and exclude build output.
+
+## Writing Docs That Pass
+
+When writing an article, keep to standard Markdown: one top-level heading, blank lines around headings, lists, and fenced code blocks, and a language on every code fence. Wrap element or tag names in backticks (e.g. `` `dprint.json` ``) so they are code spans rather than inline HTML.
+
+## Related
+
+- Stylistic conventions that go beyond linting: [Markdown Style](../conventions/markdown-style.md).
+- The pinned version used in CI: [Continuous Integration](continuous-integration.md).

--- a/docs/developer-manual/tooling/spell-checking-cspell.md
+++ b/docs/developer-manual/tooling/spell-checking-cspell.md
@@ -1,0 +1,25 @@
+# Spell Checking (CSpell)
+
+This article covers spell checking of code, comments, and documentation.
+
+[CSpell](https://cspell.org/) is configured in [`.cspell.json`](../../../tests/linters/.cspell.json) and checks English (`en-US`), alongside German, Spanish, and French dictionaries for names and terms that show up in comments or documentation.
+
+## Dictionaries
+
+Beyond the base English dictionary, the configuration adds dictionaries of common misspellings, of the keywords used by the languages in this project (`bash`, `docker`, `git`, `csharp`), and a handful of general-purpose technical dictionaries (companies, computing acronyms, file types, public licenses, software terms, and so on). The Visual Studio Code extension (see [Visual Studio Code Integration](vscode-integration.md)) ships the same English dictionaries; additional dictionaries can be installed as further Visual Studio Code extensions if needed.
+
+## Ignored Paths and Custom Words
+
+Build output (`bin` and `obj`), SVG files, and OS metadata files (`.DS_Store`, `Thumbs.db`) are ignored. Project-specific terms — proper names, tool names, and anything else not in the standard dictionaries — live in the `words` list in the config.
+
+## Running It and Handling Findings
+
+```shell
+npx --yes cspell@10.0.1 lint --config tests/linters/.cspell.json --no-progress "**/*"
+```
+
+The version matches the one [Continuous Integration](continuous-integration.md) installs, so a local run agrees with what CI reports. When a legitimate technical term or proper noun is flagged, add it to the `words` list in [`.cspell.json`](../../../tests/linters/.cspell.json) rather than rewording the text.
+
+## Related
+
+- The pinned version used in CI: [Continuous Integration](continuous-integration.md).

--- a/docs/developer-manual/tooling/vscode-integration.md
+++ b/docs/developer-manual/tooling/vscode-integration.md
@@ -1,0 +1,34 @@
+# Visual Studio Code Integration
+
+This article covers the Visual Studio Code setup under [`.vscode/`](../../../.vscode/).
+
+## Shared and Local Configuration
+
+The workspace configuration is split with the [Workspace Config Plus](https://marketplace.visualstudio.com/items?itemName=Swellaby.workspace-config-plus) extension (`Swellaby.workspace-config-plus`, recommended in [`extensions.json`](../../../.vscode/extensions.json)). For `settings` (and, if they are ever added, `tasks` and `launch`), the extension reads two source files and merges them into the file Visual Studio Code actually loads:
+
+- `settings.shared.json` — checked into Git, applies to every developer.
+- `settings.local.json` — per-developer, ignored by Git (see [`.gitignore`](../../../.gitignore)).
+- `settings.json` — **generated** by the extension from the two files above.
+
+The `settings.local.json` layer wins over `settings.shared.json`, so each developer can override or extend the shared config without touching it.
+
+### Rules
+
+- **Never edit the generated `settings.json`.** It is produced by the extension and overwritten on every change; any manual edit is lost. It is also Git-ignored — only `extensions.json` and the `*.shared.json` files are committed.
+- **Change `settings.shared.json` only for things useful to every developer.** A shared change is committed and affects the whole team, so it must be genuinely common (a project-wide setting, a lint integration).
+- **Everything personal goes in `settings.local.json`.** Anything specific to your machine or preference — icon themes, file-nesting patterns, other personal editor tweaks — belongs in the local layer, never in the shared one.
+
+## Settings
+
+[`settings.shared.json`](../../../.vscode/settings.shared.json) sets a 150-character editor ruler to match [dprint's line width](formatting-dprint.md), maps a few file names to the correct language for syntax highlighting, hides build output and OS clutter from the explorer and file watcher, protects the `main` and `development` branches from direct commits, imports the [CSpell](spell-checking-cspell.md) configuration and raises its diagnostic severity to error, points [MarkdownLint](linting-markdownlint.md) at the project configuration, and enables format-on-save with [dprint](formatting-dprint.md).
+
+## Extensions
+
+[`extensions.json`](../../../.vscode/extensions.json) recommends the extensions that back all of the above: `streetsidesoftware.code-spell-checker`, `DavidAnson.vscode-markdownlint`, `dprint.dprint`, and `Swellaby.workspace-config-plus`, plus a few editing conveniences (`TakumiI.markdowntable`, `wayou.vscode-todo-highlight`, `yzhang.markdown-all-in-one`) and `.gitignore` language support (`codezombiech.gitignore`).
+
+The CSpell and MarkdownLint extensions bundle their own engines, so the version they use can differ slightly from the pinned version [Continuous Integration](continuous-integration.md) runs — both read the same configuration files, so results should still agree. The dprint extension does not bundle a formatting engine of its own; it uses the `dprint` executable available on the machine together with the plugins declared in [`dprint.json`](../../../dprint.json), so keeping a reasonably current `dprint` installation locally keeps the editor's formatting in step with CI.
+
+## Related
+
+- The tools these settings configure: [Spell Checking (CSpell)](spell-checking-cspell.md), [MarkdownLint](linting-markdownlint.md), [dprint](formatting-dprint.md).
+- The pinned versions these extensions approximate: [Continuous Integration](continuous-integration.md).

--- a/docs/user-manual/README.md
+++ b/docs/user-manual/README.md
@@ -1,0 +1,7 @@
+# User Manual
+
+This manual is for people building a command line application with CLI.NET Core, as opposed to people working on CLI.NET Core itself (for that, see the [Developer Manual](../developer-manual/README.md)).
+
+CLI.NET Core is a .NET framework for command line applications, built in the style of ASP.NET Core: it lets you define commands and their arguments much the same way you would define actions and parameters for a Web API. The package is distributed on NuGet as `CliNetCore` (see [Architecture](../developer-manual/architecture/overview.md) for how the project and its packages are laid out).
+
+This part of the documentation is still growing alongside the framework's public API. Until it does, the [root README](../../README.md) is the best starting point for what the framework is for.


### PR DESCRIPTION
Added a `docs` directory, which contains the developer and the user manual. The documentation is written for both AI assistants and humans. The articles are short, single-topic and highly interlinked, which makes it easier for AI agents to find what they need, without filling up their context window. The `CLAUDE.md` was updated to lets Claude know about the documentation, how they work, and how they should be updated. The `CLAUDE.md` contains a hand full of golden rules that are extremely important as well as a routing table, so that Claude knows where to look in the documentation for certain important topics. Claude is instructed to update the documentation whenever a new feature is added or an old feature is updated or removed.

The documentation was written with the help of Claude Code.

Closes issue #9.